### PR TITLE
Add nested tag map support

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ tag:
   }
 
   # Set global default map
-  TLV.set_tag_map(config)
+  TLV.set_global_tag_map(config)
 
   # Set tag map for a specific instance (this will override the global setting)
   t = TLV()

--- a/README.md
+++ b/README.md
@@ -124,11 +124,15 @@ tag:
       0x09: {TLV.Config.Type: TLV, TLV.Config.Name: 'Empty'}
   }
 
-  # Set map
+  # Set global default map
   TLV.set_tag_map(config)
+
+  # Set tag map for a specific instance (this will override the global setting)
+  t = TLV()
+  t.set_local_tag_map(config)
 ```
 
-For now, only 'int', 'str', 'bytes' and 'TLV' are accepted as valid classes. Any other class will raise
+For now, only 'int', 'str', 'bytes', 'TLV', and a dictionary are accepted as valid classes. Any other class will raise
 AttributeError.
 
 If a tag map is configured, one can use the tag name to access its value:
@@ -137,6 +141,18 @@ If a tag map is configured, one can use the tag name to access its value:
  t = TLV()
  t['NUM_POINTS'] = 10
  print(t['NUM_POINTS'])
+```
+
+Nested tag maps can be configured by replacing the configured type with another configuration dictionary:
+
+```python
+  config = {
+    0x01: {TLV.Config.Name: 'FIRST_NEST', TLV.Config.Type: {
+      0x01: {TLV.Config.Name: 'SECOND_NEST', TLV.Config.Type: {
+        0x01: {TLV.Config.}
+      }}
+    }}
+  }
 ```
 
 And also can print it with all tag names instead of values:

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -18,7 +18,7 @@ class BasicTests(unittest.TestCase):
     
     @classmethod
     def setUpClass(cls):
-        TLV.set_tag_map(config)
+        TLV.set_global_tag_map(config)
 
     def setUp(self):
         self.tag = TLV(len_size=2)

--- a/tests/test_iterate.py
+++ b/tests/test_iterate.py
@@ -21,7 +21,7 @@ class TestIterate(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        TLV.set_tag_map(config)
+        TLV.set_global_tag_map(config)
 
 
     def setUp(self):

--- a/tests/test_nested_tags.py
+++ b/tests/test_nested_tags.py
@@ -1,0 +1,59 @@
+from tkinter import W
+from uttlv import *
+import unittest
+
+config = {
+    0x01: {TLV.Config.Name: 'FIRST_NEST', TLV.Config.Type: {
+        0x01: {TLV.Config.Name: 'SECOND_NEST', TLV.Config.Type: {
+            0x01: {TLV.Config.Name: 'LEAF', TLV.Config.Type: int}
+        }}
+    }},
+
+    0x02: {TLV.Config.Type: int, TLV.Config.Name: 'NON_NESTED_DATA'}
+}
+
+
+
+class TestNestedTags(unittest.TestCase):
+    '''Test various functionality with nested tag map configurations.'''
+
+    def create_tlv(self) -> TLV:
+        '''Manually create structure equivalent to config.'''
+        t = TLV()
+        t[0x01] = TLV()
+        t[0x01][0x01] = TLV()
+        t[0x01][0x01][0x01] = 1
+        t[0x02] = 42
+        return t
+
+    def test_nested_access(self):
+        t = self.create_tlv()
+        t.set_local_tag_map(config)
+
+        self.assertEqual(t['FIRST_NEST']['SECOND_NEST']['LEAF'], 1)
+
+    def test_nested_parse(self):
+        '''Tests that we can parse a nested structure from a byte array'''
+        arr = self.create_tlv().to_byte_array()
+        t = TLV()
+        t.set_local_tag_map(config)
+        t.parse_array(arr)
+
+        t['FIRST_NEST']
+        t['FIRST_NEST']['SECOND_NEST']
+        self.assertEqual(t['FIRST_NEST']['SECOND_NEST']['LEAF'], 1)
+
+    def check_if_value_exists(self, obj, value):
+        try:
+            obj[value]
+            self.fail("Extra non-TLV value was created")
+        # KeyError is the final error generated if we have a tag map defined but the object isn't there
+        except KeyError:
+            pass
+
+    def test_only_nested_tlvs_created(self):
+        t = TLV()
+        t.set_local_tag_map(config)
+
+        self.check_if_value_exists(t, 'NON_NESTED_DATA')
+        self.check_if_value_exists(t['FIRST_NEST']['SECOND_NEST'], 'LEAF')

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -19,7 +19,7 @@ class TestParser(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        TLV.set_tag_map(config)
+        TLV.set_global_tag_map(config)
 
     def setUp(self):
         self.tlv = TLV(len_size=2)

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -18,7 +18,7 @@ config = {
 class TreeTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        TLV.set_tag_map(config)
+        TLV.set_global_tag_map(config)
 
     def setUp(self):
         self.tag = TLV()

--- a/uttlv/encoder.py
+++ b/uttlv/encoder.py
@@ -17,7 +17,7 @@ class DefaultEncoder(object):
             pass
         return str(obj)
 
-    def parse(self, obj, cls=None):
+    def parse(self, obj, cls):
         try:
             cls.parse_array(obj)
             return cls
@@ -33,7 +33,7 @@ class IntEncoder(DefaultEncoder):
             return obj.to_bytes(4, byteorder='big')
         return super().default(obj)
 
-    def parse(self, obj, cls=None):
+    def parse(self, obj, _cls):
         return int.from_bytes(obj, byteorder='big')
 
 
@@ -44,7 +44,7 @@ class AsciiEncoder(DefaultEncoder):
             return obj.encode('ascii')
         return super().default(obj)
 
-    def parse(self, obj, cls=None):
+    def parse(self, obj, _cls):
         return obj.decode('ascii')
 
 
@@ -58,7 +58,7 @@ class BytesEncoder(DefaultEncoder):
     def to_string(self, obj, offset=0, use_names=False):
         return str(hexlify(obj), 'ascii')
 
-    def parse(self, obj, cls=None):
+    def parse(self, obj, _cls):
         return obj
 
 
@@ -69,7 +69,7 @@ class Utf8Encoder(DefaultEncoder):
             return obj.encode('utf8')
         return super().default(obj)
 
-    def parse(self, obj, cls=None):
+    def parse(self, obj, _cls):
         return obj.decode('utf8')
 
 
@@ -80,7 +80,7 @@ class Utf16Encoder(DefaultEncoder):
             return obj.encode('utf16')
         return super().default(obj)
 
-    def parse(self, obj, cls=None):
+    def parse(self, obj, _cls):
         return obj.decode('utf16')
 
 
@@ -91,7 +91,7 @@ class Utf32Encoder(DefaultEncoder):
             return obj.encode('utf32')
         return super().default(obj)
 
-    def parse(self, obj, cls=None):
+    def parse(self, obj, _cls):
         return obj.decode('utf32')
 
 
@@ -100,9 +100,7 @@ class NestedEncoder(DefaultEncoder):
     def __init__(self, tag_map):
         self.tag_map = tag_map
 
-    def parse(self, obj, cls=None):
-        # TODO need to have a proper check, this fails because TLV would be a circular import
-        #if type(cls) is TLV:
+    def parse(self, obj, cls):
         cls.set_local_tag_map(self.tag_map)
 
         return super().parse(obj, cls)

--- a/uttlv/encoder.py
+++ b/uttlv/encoder.py
@@ -93,3 +93,16 @@ class Utf32Encoder(DefaultEncoder):
 
     def parse(self, obj, cls=None):
         return obj.decode('utf32')
+
+
+class NestedEncoder(DefaultEncoder):
+
+    def __init__(self, tag_map):
+        self.tag_map = tag_map
+
+    def parse(self, obj, cls=None):
+        # TODO need to have a proper check, this fails because TLV would be a circular import
+        #if type(cls) is TLV:
+        cls.set_local_tag_map(self.tag_map)
+
+        return super().parse(obj, cls)

--- a/uttlv/tlv.py
+++ b/uttlv/tlv.py
@@ -91,6 +91,7 @@ class TLV:
         return TLVIterator(self)
 
     def _new_equivalent_tlv(self) -> TLV:
+        '''Creates a new TLV object with the same decode settings as self. Useful for parsing nested structures.'''
         return TLV(self.indent, self.tag_size, self.len_size, self.endian)
 
     @classmethod

--- a/uttlv/tlv.py
+++ b/uttlv/tlv.py
@@ -95,8 +95,17 @@ class TLV:
 
     @classmethod
     def set_tag_map(cls, map: Dict) -> None:
-        '''Set a map for tag.
-        
+        '''Set a tag map globally for all classes (DEPRECATED, please use set_global_tag_map)
+
+        :args:
+            map: dict with keys names
+        '''
+        cls.set_global_tag_map(map)
+
+    @classmethod
+    def set_global_tag_map(cls, map: Dict) -> None:
+        '''Set a tag map globally for all classes
+
         :args:
             map: dict with keys names
         '''

--- a/uttlv/tlv.py
+++ b/uttlv/tlv.py
@@ -83,6 +83,9 @@ class TLV:
     def __iter__(self):
         return TLVIterator(self)
 
+    def _new_equivalent_tlv(self) -> TLV:
+        return TLV(self.indent, self.tag_size, self.len_size, self.endian)
+
     @classmethod
     def set_tag_map(cls, map: Dict) -> None:
         '''Set a map for tag.

--- a/uttlv/tlv.py
+++ b/uttlv/tlv.py
@@ -43,7 +43,7 @@ class TLV:
         self.len_size = len_size
         self.endian = endian
         self._items = {}
-        
+
     def __setitem__(self, key, value):
         real_key = self.__getkey__(key)
         self.check_key(real_key)
@@ -98,7 +98,7 @@ class TLV:
             if t not in al_types:
                 raise AttributeError(f'Invalid tag type {t} for {k} -> {v}')
         cls.tag_map = map
-    
+
     def check_key(self, key: int) -> bool:
         '''Check if key is valid is inside limits.
         
@@ -138,7 +138,7 @@ class TLV:
             raise ValueError(f'{value} takes up {required_len_size} bytes, but len_size was defined as {self.len_size}')
 
         return len(value).to_bytes(self.len_size, byteorder=self.endian)
-        
+
     def to_byte_array(self) -> bytes:
         '''Translate all keys and values into an array of bytes.'''
         values = bytes()
@@ -211,7 +211,7 @@ class TLV:
             self.__setitem__(t, v)
         # Done parsing
         return True
-                    
+
 
 class EmptyTLV(TLV):
     '''Empty TLV'''
@@ -227,7 +227,7 @@ class EmptyTLV(TLV):
         len_size = self.len_size or 1
         value += int(0).to_bytes(len_size, byteorder='big')
         return value
-        
+
     def tree(self, offset: int = 0, use_names: bool = False) -> str:
         s = '' if offset == 0 else '\r\n'
         tag = str(hexlify(int(self.tag).to_bytes(self.tag_size, byteorder='big')), 'ascii')


### PR DESCRIPTION
This PR addresses #4 

Currently a draft because of several issues:
1. The testing I've added isn't terribly exhaustive
2.  `set_tag_map` should likely be renamed to `set_global_tag_map` and `set_local_tag_map` could be renamed `set_tag_map`, but I wanted to keep the changes as non-breaking as possible. I'll leave that choice up to you and I can just implement it.
3. There's a small TODO in encoder.py, the implementation as-is may be unsound, needs a little more work/testing to either add proper checks or eliminate the need for them. I'm out of energy for that ATM so I'll come back to it later.