### PR TITLE
int_8_16_64: Implement work with int8, int16, int64

### DIFF
--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1,4 +1,4 @@
-from uttlv import TLV, EmptyTLV
+from uttlv import TLV, EmptyTLV, Int8, Int16, Int64
 
 
 class TestBasic:
@@ -10,6 +10,60 @@ class TestBasic:
         # Create an array
         v = list(tag.to_byte_array())
         exp = [0x01, 0x00, 0x04, 0x00, 0x00, 0x00, 0x0A]
+        # Check value
+        assert exp == v
+
+    def test_int8_one(self, tag):
+        """Test if a TLV object is corrected set to an array"""
+        tag[0x01] = Int8(0xde)
+        # Create an array
+        v = list(tag.to_byte_array())
+        exp = [0x01, 0x00, 0x01, 0xde]
+        # Check value
+        assert exp == v
+
+    def test_int16_one(self, tag):
+        """Test if a TLV object is corrected set to an array"""
+        tag[0x01] = Int16(0xdead)
+        # Create an array
+        v = list(tag.to_byte_array())
+        exp = [0x01, 0x00, 0x02, 0xde, 0xad]
+        # Check value
+        assert exp == v
+
+    def test_int64_one(self, tag):
+        """Test if a TLV object is corrected set to an array"""
+        tag[0x01] = Int64(0xdeadbeefdeadbeef)
+        # Create an array
+        v = list(tag.to_byte_array())
+        exp = [0x01, 0x00, 0x08, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef]
+        # Check value
+        assert exp == v
+
+    def test_int8_little(self, tag_little):
+        """Test if a TLV object is corrected set to an array"""
+        tag_little[0x01] = Int8(0xad)
+        # Create an array
+        v = list(tag_little.to_byte_array())
+        exp = [0x01, 0x01, 0x00, 0xad]
+        # Check value
+        assert exp == v
+
+    def test_int16_little(self, tag_little):
+        """Test if a TLV object is corrected set to an array"""
+        tag_little[0x01] = Int16(0xdead)
+        # Create an array
+        v = list(tag_little.to_byte_array())
+        exp = [0x01, 0x02, 0x00, 0xad, 0xde]
+        # Check value
+        assert exp == v
+
+    def test_int64_little(self, tag_little):
+        """Test if a TLV object is corrected set to an array"""
+        tag_little[0x01] = Int64(0xdeadbeefdeadbeef)
+        # Create an array
+        v = list(tag_little.to_byte_array())
+        exp = [0x01, 0x08, 0x00, 0xef, 0xbe, 0xad, 0xde, 0xef, 0xbe, 0xad, 0xde]
         # Check value
         assert exp == v
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -11,12 +11,54 @@ class TestParser:
 
         assert tag[0x01] == 16
 
+    def test_int8(self, tag):
+        """Test single int 8-bit array parser."""
+        arr = [0x01, 0x00, 0x01, 0xad]
+        tag.parse_array(arr)
+
+        assert tag[0x01] == 0xad
+
+    def test_int16(self, tag):
+        """Test single int 16-bit array parser."""
+        arr = [0x01, 0x00, 0x02, 0xde, 0xad]
+        tag.parse_array(arr)
+
+        assert tag[0x01] == 0xdead
+
+    def test_int64(self, tag):
+        """Test single int 64-bit array parser."""
+        arr = [0x01, 0x00, 0x08, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef]
+        tag.parse_array(arr)
+
+        assert tag[0x01] == 0xdeadbeefdeadbeef
+
     def test_little_end(self, tag_little):
-        """Test single int array parser."""
+        """Test single int array parser from little endian."""
         arr = [0x01, 0x04, 0x00, 0x10, 0x00, 0x00, 0x00]
         tag_little.parse_array(arr)
 
         assert tag_little[0x01] == 16
+
+    def test_int8_little(self, tag_little):
+        """Test single int 8-bit array parser from little endian."""
+        arr = [0x01, 0x01, 0x00, 0xde]
+        tag_little.parse_array(arr)
+
+        assert tag_little[0x01] == 0xde
+
+    def test_int16_little(self, tag_little):
+        """Test single int 16-bit array parser from little endian."""
+        arr = [0x01, 0x02, 0x00, 0xad, 0xde]
+        tag_little.parse_array(arr)
+
+        assert tag_little[0x01] == 0xdead
+
+    def test_int64_little(self, tag_little):
+        """Test single int 64-bit array parser from little endian."""
+        arr = [0x01, 0x08, 0x00, 0xef, 0xbe, 0xad, 0xde, 0xef, 0xbe, 0xad, 0xde]
+        tag_little.parse_array(arr)
+
+        assert tag_little[0x01] == 0xdeadbeefdeadbeef
 
     def test_single_str(self, tag):
         """Test single str array parser."""

--- a/uttlv/__init__.py
+++ b/uttlv/__init__.py
@@ -3,12 +3,15 @@ from .encoder import (
     AsciiEncoder,
     BytesEncoder,
     DefaultEncoder,
-    IntEncoder,
+    Int8Encoder,
+    Int16Encoder,
+    Int32Encoder,
+    Int64Encoder,
     Utf8Encoder,
     Utf16Encoder,
     Utf32Encoder,
 )
-from .tlv import TLV, EmptyTLV
+from .tlv import TLV, EmptyTLV, Int8, Int16, Int64
 
 # Package version
 __version__ = "0.7.0"

--- a/uttlv/encoder.py
+++ b/uttlv/encoder.py
@@ -26,10 +26,40 @@ class DefaultEncoder(object):
         return obj
 
 
-class IntEncoder(DefaultEncoder):
+class Int8Encoder(DefaultEncoder):
+    def default(self, obj, _cls):
+        if isinstance(obj, int):
+            return obj.to_bytes(1, byteorder=_cls.endian)
+        return super().default(obj)
+
+    def parse(self, obj, _cls):
+        return int.from_bytes(obj, byteorder=_cls.endian)
+
+
+class Int16Encoder(DefaultEncoder):
+    def default(self, obj, _cls):
+        if isinstance(obj, int):
+            return obj.to_bytes(2, byteorder=_cls.endian)
+        return super().default(obj)
+
+    def parse(self, obj, _cls):
+        return int.from_bytes(obj, byteorder=_cls.endian)
+
+
+class Int32Encoder(DefaultEncoder):
     def default(self, obj, _cls):
         if isinstance(obj, int):
             return obj.to_bytes(4, byteorder=_cls.endian)
+        return super().default(obj)
+
+    def parse(self, obj, _cls):
+        return int.from_bytes(obj, byteorder=_cls.endian)
+
+
+class Int64Encoder(DefaultEncoder):
+    def default(self, obj, _cls):
+        if isinstance(obj, int):
+            return obj.to_bytes(8, byteorder=_cls.endian)
         return super().default(obj)
 
     def parse(self, obj, _cls):

--- a/uttlv/tlv.py
+++ b/uttlv/tlv.py
@@ -8,7 +8,10 @@ from typing import Any, Dict
 from .encoder import (
     BytesEncoder,
     DefaultEncoder,
-    IntEncoder,
+    Int8Encoder,
+    Int16Encoder,
+    Int32Encoder,
+    Int64Encoder,
     NestedEncoder,
     Utf8Encoder,
 )
@@ -309,9 +312,24 @@ class TLVIterator:
         return next(self._it)
 
 
+class Int8(int):
+    pass
+
+
+class Int16(int):
+    pass
+
+
+class Int64(int):
+    pass
+
+
 ALLOWED_TYPES = {
     TLV: DefaultEncoder,
-    int: IntEncoder,
+    Int8: Int8Encoder,
+    Int16: Int16Encoder,
+    int: Int32Encoder,
+    Int64: Int64Encoder,
     bytes: BytesEncoder,
     str: Utf8Encoder,
 }


### PR DESCRIPTION
One of possible implement works with `Int8`, `Int16` and `Int64`. I'm using `int` as `int32`. The same way using in `cpp`.
Tests show that it's works. But I don't know Python well enough to determine whether it's acceptable.
And I did not correct the `README`, because I had never written anything like this before, just copy-paste. 

Partial fix for #6 