### PR TITLE
Fix decoding of length sizes greater than 1

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -304,3 +304,10 @@ class TestParser:
         auto_len_tag.parse_array(arr)
 
         assert v.decode("ascii") == auto_len_tag[0x03]
+
+    def test_auto_len_multi_byte_read(self, auto_len_tag):
+        """Test auto length decoder with multi-byte length"""
+        arr = [0x01, 0x81, 0x01, 0x01, 0x02, 0x01, 0x02]
+        auto_len_tag.parse_array(arr)
+        assert auto_len_tag[0x01] == 0x01
+        assert auto_len_tag[0x02] == 0x02

--- a/uttlv/tlv.py
+++ b/uttlv/tlv.py
@@ -247,7 +247,10 @@ class TLV:
             # Len value
             aux = aux[self.tag_size :]
             len_size = self.len_size or self.decode_len_size(aux)
-            length = int.from_bytes(aux[:len_size], byteorder=self.endian)
+            if len_size is 1:
+                length = int.from_bytes(aux[:len_size], byteorder=self.endian)
+            else:
+                length = int.from_bytes(aux[1:len_size], byteorder=self.endian)
             # Value
             aux = aux[len_size:]
             value = aux[:length]

--- a/uttlv/tlv.py
+++ b/uttlv/tlv.py
@@ -247,10 +247,8 @@ class TLV:
             # Len value
             aux = aux[self.tag_size :]
             len_size = self.len_size or self.decode_len_size(aux)
-            if len_size is 1:
-                length = int.from_bytes(aux[:len_size], byteorder=self.endian)
-            else:
-                length = int.from_bytes(aux[1:len_size], byteorder=self.endian)
+            len_size_start = (0 if self.len_size != None or len_size == 1 else 1)
+            length = int.from_bytes(aux[len_size_start:len_size], byteorder=self.endian)
             # Value
             aux = aux[len_size:]
             value = aux[:length]


### PR DESCRIPTION
This pull fixes a bug in the `decode_len_size` function. Previously, all bytes were included when decoding the length size, which would lead to enormous lengths, capturing the rest of the TLV data in one tag.